### PR TITLE
fix: rename createComponent to defineComponent

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Including most of the API of Vue3. You can type `reactive`, choose `reactive`, a
 | `import` | `import {...} from "@vue/composition-api"` |
 | `import` | `import {...} from 'vue'` |
 | `newVue` | `newVue({...})` |
-| `createComponent` | `createComponent({...})` |
+| `defineComponent` | `defineComponent({...})` |
 | `export` | `export default { ... }` |
 | `setup` | `setup(${...}) {...}` |
 | `reactive` | `const data = reactive({...})` |
@@ -108,16 +108,16 @@ After installing the plugin you can use the Composition API to compose your comp
 
 **This plugin requires TypeScript version >3.5.1. If you are using `vetur`, make sure to set `vetur.useWorkspaceDependencies` to `true`.**
 
-To let TypeScript properly infer types inside Vue component options, you need to define components with `createComponent`:
+To let TypeScript properly infer types inside Vue component options, you need to define components with `defineComponent`:
 
 **请使用最新版的 TypeScript，如果你使用了 `vetur`，请将 `vetur.useWorkspaceDependencies` 设为 `true`。**
 
-为了让 TypeScript 正确的推导类型，我们必须使用 `createComponent` 来定义组件:
+为了让 TypeScript 正确的推导类型，我们必须使用 `defineComponent` 来定义组件:
 
 ```ts
-import { createComponent } from '@vue/composition-api';
+import { defineComponent } from '@vue/composition-api';
 
-const Component = createComponent({
+const Component = defineComponent({
   // 启用类型推断
 });
 

--- a/snippets/javascript.json
+++ b/snippets/javascript.json
@@ -13,14 +13,14 @@
         ],
         "description": "import"
     },
-    "createComponent": {
-        "prefix": "createComponent",
+    "defineComponent": {
+        "prefix": "defineComponent",
         "body": [
-            "createComponent({",
+            "defineComponent({",
             "\t$1",
             "})"
         ],
-        "description": "createComponent()"
+        "description": "defineComponent()"
     },
     "export": {
         "prefix": "export default",


### PR DESCRIPTION
createComponent is deprecated.
https://github.com/vuejs/composition-api/blob/master/README.zh-CN.md
![image](https://user-images.githubusercontent.com/3996569/81054750-f49aad80-8ef9-11ea-81e8-5742e70b5f2c.png)
